### PR TITLE
Cl/tf pipeline secretsfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,14 +131,15 @@ echo "##vso[task.setvariable variable=ARM_SUBSCRIPTION_ID]$ARM_SUBSCRIPTION_ID"
 
 echo "##vso[task.setvariable variable=ARM_CLIENT_ID]$servicePrincipalId"
 echo "##vso[task.setvariable variable=ARM_TENANT_ID]$tenantId"
-echo "##vso[task.setvariable variable=ARM_CLIENT_SECRET]$servicePrincipalKey"
 ```
 
-6. In future tasks that require use of Terraform scripts, set the env: block like below. This will allow Terraform's Azurerm to automatically authenticate to your Azure subscription.
+6. It is not recommended to pass use these commands to set secrets. Thus, we will manually set the pipeline variable for client secret. Head to the pipeline, then go to **Edit** --> **Variables** and hit the plus sign next to the search bar. Enter in the variable name, and the client secret copied earlier as the value. Be sure to check the box that says "Keep this value secret".
+
+7. In future tasks that require use of Terraform scripts, set the env: block like below. This will allow Terraform's Azurerm to automatically authenticate to your Azure subscription.
 ```bash
 env:
   ARM_CLIENT_ID: $(ARM_CLIENT_ID)
-  ARM_CLIENT_SECRET: $(ARM_CLIENT_SECRET)
+  ARM_CLIENT_SECRET: $(SECRET_VARIABLE_NAME)
   ARM_SUBSCRIPTION_ID: $(ARM_SUBSCRIPTION_ID)
   ARM_TENANT_ID: $(ARM_TENANT_ID)
 ```

--- a/ado/steps/azure-pipelines-tf.yml
+++ b/ado/steps/azure-pipelines-tf.yml
@@ -82,7 +82,6 @@ stages:
                 echo "##vso[task.setvariable variable=ARM_CLIENT_ID]$servicePrincipalId"
                 echo "##vso[task.setvariable variable=ARM_SUBSCRIPTION_ID]$ARM_SUBSCRIPTION_ID"
                 echo "##vso[task.setvariable variable=ARM_TENANT_ID]$tenantId"
-                echo "##vso[task.setvariable variable=ARM_CLIENT_SECRET]$servicePrincipalKey"
               addSpnToEnvironment: true
 
           - task: Bash@3
@@ -99,7 +98,7 @@ stages:
             env:
               TF_TOKEN_app_terraform_io: $(TERRAFORM_TOKEN)
               ARM_CLIENT_ID: $(ARM_CLIENT_ID)
-              ARM_CLIENT_SECRET: $(ARM_CLIENT_SECRET)
+              ARM_CLIENT_SECRET: $(SERVICE_PRINCIPAL_KEY)
               ARM_SUBSCRIPTION_ID: $(ARM_SUBSCRIPTION_ID)
               ARM_TENANT_ID: $(ARM_TENANT_ID)
             displayName: "Terraform Plan"
@@ -116,6 +115,6 @@ stages:
             env:
               TF_TOKEN_app_terraform_io: $(TERRAFORM_TOKEN)
               ARM_CLIENT_ID: $(ARM_CLIENT_ID)
-              ARM_CLIENT_SECRET: $(ARM_CLIENT_SECRET)
+              ARM_CLIENT_SECRET: $(SERVICE_PRINCIPAL_KEY)
               ARM_SUBSCRIPTION_ID: $(ARM_SUBSCRIPTION_ID)
               ARM_TENANT_ID: $(ARM_TENANT_ID)


### PR DESCRIPTION
Not recommended to directly set secrets as variables in yaml script. Introduced new changes to fix this.